### PR TITLE
fix: remove unnecessary wg.Done

### DIFF
--- a/v2/core/core.go
+++ b/v2/core/core.go
@@ -81,8 +81,6 @@ func DefaultMod(targets interface{}, config Config) {
 		if Opt.PluginDebug == true {
 			debug.PrintStack()
 		}
-
-		wgs.Done()
 	}))
 	defer scanPool.Release()
 


### PR DESCRIPTION
golang panic 的时候是会执行defer块内的东西的，没必要在异常处理这里再次wg.Done
https://go.dev/play/p/K0RrI4BEsck