### PR TITLE
fix: correct typo unkown -> unknown in v2/pkg/utils.go

### DIFF
--- a/v2/pkg/utils.go
+++ b/v2/pkg/utils.go
@@ -18,7 +18,7 @@ var (
 	DefaultMaxSize = 1024 * 16 // 16k
 )
 
-// return open: 0, closed: 1, filtered: 2, noroute: 3, denied: 4, down: 5, error_host: 6, unkown: -1
+// return open: 0, closed: 1, filtered: 2, noroute: 3, denied: 4, down: 5, error_host: 6, unknown: -1
 var PortStat = map[int]string{
 	0:  "open",
 	1:  "closed",


### PR DESCRIPTION
## Description

Fix a typo in `v2/pkg/utils.go:21`: `unkown` should be `unknown`.

## Changes

- `v2/pkg/utils.go:21`: 1 line changed in comment

Fixes issue #130.