### PR TITLE
fix: correct unkown→unknown typo in utils.go comment

### DIFF
--- a/v2/pkg/utils.go
+++ b/v2/pkg/utils.go
@@ -18,7 +18,7 @@ var (
 	DefaultMaxSize = 1024 * 16 // 16k
 )
 
-// return open: 0, closed: 1, filtered: 2, noroute: 3, denied: 4, down: 5, error_host: 6, unkown: -1
+// return open: 0, closed: 1, filtered: 2, noroute: 3, denied: 4, down: 5, error_host: 6, unknown: -1
 var PortStat = map[int]string{
 	0:  "open",
 	1:  "closed",


### PR DESCRIPTION
Hi! This PR fixes a simple typo in the comment of `v2/pkg/utils.go` line 21: `unkown` → `unknown`.

The actual map value `-1: "unknown"` was already correct; this just fixes the inline comment to match.

1 file, 1 line change. Thanks for maintaining gogo!